### PR TITLE
Fix gmusicapi version number comparisons

### DIFF
--- a/GoogleMusic/Plugin.pm
+++ b/GoogleMusic/Plugin.pm
@@ -58,7 +58,9 @@ sub initPlugin {
 	$VERSION = $class->_pluginDataFor('version');
 
 	# Chech version of gmusicapi first
-	if (!blessed($googleapi) || (Plugins::GoogleMusic::GoogleAPI::get_version() lt '4.0.0')) {
+	if (!blessed($googleapi) ||
+	    (version->parse(Plugins::GoogleMusic::GoogleAPI::get_version()) lt 
+	     version->parse('4.0.0'))) {
 		$class->SUPER::initPlugin(
 			tag    => 'googlemusic',
 			feed   => \&badVersion,

--- a/GoogleMusic/Radio.pm
+++ b/GoogleMusic/Radio.pm
@@ -426,7 +426,8 @@ sub fetchStationTracks {
 
 	# Get new tracks for the station
 	eval {
-		if (Plugins::GoogleMusic::GoogleAPI::get_version() lt '4.1.0') {
+		if (version->parse(Plugins::GoogleMusic::GoogleAPI::get_version()) lt
+		    version->parse('4.1.0')) {
 			$googleTracks = $googleapi->get_station_tracks($station, $PLAYLIST_MAXLENGTH);
 		} else {
 			$googleTracks = $googleapi->get_station_tracks($station, $PLAYLIST_MAXLENGTH, $recentlyPlayed);


### PR DESCRIPTION
Checking the version number of the gmusicapi module is converted to using perl's version->parse() function, which simplifies the comparison of traditionally formatted, string-valued version numbers. This patch enables the use of the 10.x series of gmusicapi by the plugin.